### PR TITLE
ALP4-836 Implemented matcher to ignore milliseconds in unit tests for…

### DIFF
--- a/src/test/java/uk/nhs/careconnect/nosql/support/assertions/DocumentReferenceAssertions.java
+++ b/src/test/java/uk/nhs/careconnect/nosql/support/assertions/DocumentReferenceAssertions.java
@@ -2,6 +2,7 @@ package uk.nhs.careconnect.nosql.support.assertions;
 
 import org.hl7.fhir.dstu3.model.DocumentReference;
 import uk.nhs.careconnect.nosql.entities.DocumentReferenceEntity;
+import uk.nhs.careconnect.nosql.support.matchers.DateMatchers;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -12,14 +13,13 @@ import static uk.nhs.careconnect.nosql.support.assertions.ReferenceAssertions.as
 public class DocumentReferenceAssertions {
 
     public static void assertThatDocumentReferenceIsEqual(DocumentReferenceEntity actual, DocumentReference expected) {
-        //TODO: fix date precision issue
-//        assertThat(actual.getCreatedDate(), is(expected.getCreated()));
+        assertThat(actual.getCreatedDate(), is(DateMatchers.equalIgnoringMilliSeconds(expected.getCreated())));
         assertThatCodeableConceptIsEqual(actual.getType(), expected.getType());
         assertThatReferenceIsEqual(actual.getPatient(), expected.getSubject());
         assertThatIdentifiersAreEqual(actual.getIdentifier(), expected.getIdentifier());
         assertThatCodeableConceptIsEqual(actual.getPractice(), expected.getContext().getPracticeSetting());
-//        assertThat(actual.getPeriod().getStart(), is(expected.getContext().getPeriod().getStart()));
-//        assertThat(actual.getPeriod().getEnd(), is(expected.getContext().getPeriod().getEnd()));
+        assertThat(actual.getPeriod().getStart(), is(DateMatchers.equalIgnoringMilliSeconds(expected.getContext().getPeriod().getStart())));
+        assertThat(actual.getPeriod().getEnd(), is(DateMatchers.equalIgnoringMilliSeconds(expected.getContext().getPeriod().getEnd())));
         assertThat(actual.getFhirDocumentReference().getId(), is(expected.getId()));
     }
 

--- a/src/test/java/uk/nhs/careconnect/nosql/support/matchers/DateMatchers.java
+++ b/src/test/java/uk/nhs/careconnect/nosql/support/matchers/DateMatchers.java
@@ -1,0 +1,35 @@
+package uk.nhs.careconnect.nosql.support.matchers;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+public class DateMatchers {
+
+    public static Matcher<Date> equalIgnoringMilliSeconds(Date expectedDate) {
+        return new BaseMatcher<Date>() {
+
+            private SimpleDateFormat formatter = new SimpleDateFormat("dd MM yyyy HH:mm:ss");
+
+            @Override
+            public boolean matches(Object actualDate) {
+                return formatter.format(actualDate).equals(formatter.format(expectedDate));
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendValue(formatter.format(expectedDate));
+            }
+
+            @Override
+            public void describeMismatch(Object item, Description description) {
+                description.appendText("was ").appendValue(formatter.format(item));
+            }
+
+        };
+    }
+
+}


### PR DESCRIPTION
… document reference dates